### PR TITLE
Dust Off, Prep Release

### DIFF
--- a/src/staffbase-widget-dacast.tsx
+++ b/src/staffbase-widget-dacast.tsx
@@ -68,9 +68,10 @@ export const StaffbaseWidgetDacast = ({ contentid }: StaffbaseWidgetDacastProps)
     minHeight: "300px",
     overflow: "hidden",
     height: "100%",
+    aspectRatio: "16/9",
   }}>
 
-    <div id="dacast-player" hidden={playerHidden} style={{ position: 'relative' }}></div>
+    <div id="dacast-player" hidden={playerHidden} style={{ position: 'relative', minHeight: "360px", width: "100%", height: "100%"}}></div>
   </div>
     ;
 };


### PR DESCRIPTION
Originally I thought this branch would require changes to enable Dacast-Hosted VOD Video playback (in addition to the previously-tested live playback) but ultimately the same contentID parameter works fine - so this is instead just a PR to get the widget working again as it had broken in the interim, presumably due to changes in the DaCast Player.

